### PR TITLE
[deploy/cloud-lifecycle-controller.service] Updating /usr/bin/cloud-lifecycle-controller to /usr/local/bin/cloud-lifecycle-controller

### DIFF
--- a/deploy/cloud-lifecycle-controller.service
+++ b/deploy/cloud-lifecycle-controller.service
@@ -13,4 +13,4 @@ EnvironmentFile=/etc/sysconfig/kube-common
 # For CA certs and keys
 EnvironmentFile=/etc/sysconfig/kube-pki
 EnvironmentFile=/etc/sysconfig/cloud-lifecycle-controller
-ExecStart=/usr/bin/cloud-lifecycle-controller -kubeconfig $KUBECONFIG -leader-elect -cloud $CLOUD
+ExecStart=/usr/local/bin/cloud-lifecycle-controller -kubeconfig $KUBECONFIG -leader-elect -cloud $CLOUD


### PR DESCRIPTION
Fixes error: `Failed at step EXEC spawning /usr/bin/cloud-lifecycle-controller: No such file or directory` and updates to correct location of `cloud-lifecycle-controller`

```shell
$ ls /usr/bin/cloud-lifecycle-controller
ls: cannot access /usr/bin/cloud-lifecycle-controller: No such file or directory
$ which cloud-lifecycle-controller
/usr/local/bin/cloud-lifecycle-controller
```